### PR TITLE
Generalize the mopafy! macro to work on parametrized traits

### DIFF
--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -19,7 +19,7 @@ extern crate mopa;
 extern crate alloc;
 
 #[cfg(feature = "no_std_examples")]
-mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
+pub mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
     use alloc::boxed::Box;
 
     trait Panic { fn panic(&self) { } }
@@ -44,4 +44,7 @@ mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
 
     #[lang = "eh_personality"] extern fn eh_personality() {}
     #[lang = "panic_fmt"] extern fn panic_fmt() {}
+    #[lang = "eh_unwind_resume"] extern fn eh_unwind_resume(_: *mut u8) {}
+    #[no_mangle] pub extern fn rust_eh_register_frames () {}
+    #[no_mangle] pub extern fn rust_eh_unregister_frames () {}
 }

--- a/examples/no_std_or_alloc.rs
+++ b/examples/no_std_or_alloc.rs
@@ -19,7 +19,7 @@ extern crate mopa;
 extern crate libc;
 
 #[cfg(feature = "no_std_examples")]
-mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
+pub mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
     trait Panic { fn panic(&self) { } }
 
     trait PanicAny: Panic + ::mopa::Any { }
@@ -42,4 +42,7 @@ mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
 
     #[lang = "eh_personality"] extern fn eh_personality() {}
     #[lang = "panic_fmt"] extern fn panic_fmt() {}
+    #[lang = "eh_unwind_resume"] extern fn eh_unwind_resume(_: *mut u8) {}
+    #[no_mangle] pub extern fn rust_eh_register_frames () {}
+    #[no_mangle] pub extern fn rust_eh_unregister_frames () {}
 }


### PR DESCRIPTION
Adds to the mopafy! macro so that it can take traits with parameters like `mopafy!(Paremetrized<A, B>)`. 

I had to use parentheses in the variants which actually do something to avoid ambiguity but otherwise it is a quite small generalization. This does not make it possible to add trait bounds to those parameters as I do not know a good way to do this in macros but for my purposes I did not need that anyway.
