### PR TITLE
Add the ability to use generic constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,8 @@ readme = "README.md"
 keywords = ["any", "macro"]
 license = "MIT/Apache-2.0"
 
+[dependencies]
+parse-generics-shim = "0.*"
+
 [features]
 no_std_examples = []

--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -16,6 +16,10 @@ fn main() { }
 extern crate mopa;
 
 #[cfg(feature = "no_std_examples")]
+#[macro_use]
+extern crate parse_generics_shim;
+
+#[cfg(feature = "no_std_examples")]
 extern crate alloc;
 
 #[cfg(feature = "no_std_examples")]

--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -19,7 +19,7 @@ extern crate mopa;
 extern crate alloc;
 
 #[cfg(feature = "no_std_examples")]
-mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
+pub mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
     use alloc::boxed::Box;
 
     trait Panic { fn panic(&self) { } }
@@ -44,4 +44,7 @@ mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
 
     #[lang = "eh_personality"] extern fn eh_personality() {}
     #[lang = "panic_fmt"] extern fn panic_fmt() {}
+    #[lang = "eh_unwind_resume"] extern fn eh_unwind_resume(_: *mut u8) {}
+    #[no_mangle] pub extern fn rust_eh_register_frames () {}
+    #[no_mangle] pub extern fn rust_eh_unregister_frames () {}
 }

--- a/examples/no_std_or_alloc.rs
+++ b/examples/no_std_or_alloc.rs
@@ -16,6 +16,10 @@ fn main() { }
 extern crate mopa;
 
 #[cfg(feature = "no_std_examples")]
+#[macro_use]
+extern crate parse_generics_shim;
+
+#[cfg(feature = "no_std_examples")]
 extern crate libc;
 
 #[cfg(feature = "no_std_examples")]
@@ -24,7 +28,7 @@ pub mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
 
     trait PanicAny: Panic + ::mopa::Any { }
 
-    mopafy!(PanicAny, only core);
+    mopafy_only_core!(PanicAny);
 
     impl Panic for i32 { }
 

--- a/examples/no_std_or_alloc.rs
+++ b/examples/no_std_or_alloc.rs
@@ -19,7 +19,7 @@ extern crate mopa;
 extern crate libc;
 
 #[cfg(feature = "no_std_examples")]
-mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
+pub mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
     trait Panic { fn panic(&self) { } }
 
     trait PanicAny: Panic + ::mopa::Any { }
@@ -42,4 +42,7 @@ mod silly_wrapper_to_save_writing_the_whole_cfg_incantation_on_every_item {
 
     #[lang = "eh_personality"] extern fn eh_personality() {}
     #[lang = "panic_fmt"] extern fn panic_fmt() {}
+    #[lang = "eh_unwind_resume"] extern fn eh_unwind_resume(_: *mut u8) {}
+    #[no_mangle] pub extern fn rust_eh_register_frames () {}
+    #[no_mangle] pub extern fn rust_eh_unregister_frames () {}
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate mopa;
+#[macro_use]
+extern crate parse_generics_shim;
 
 use mopa::Any;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,7 +566,6 @@ mod tests {
 
     #[test]
     fn constrained() {
-        let i123 = 123;
         let mut benny = Benny { kilograms_of_food: 13 };
         let mut person: Box<Constrained<u8, f32, DeepStruct>> = Box::new(benny.clone());
         assert!(person.is::<Benny>());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@
 //!    ```rust
 //!    #[macro_use]
 //!    extern crate mopa;
+//!    #[macro_use]
+//!    extern crate parse_generics_shim;
 //!    # fn main() { }
 //!    ```
 //!
@@ -53,6 +55,8 @@
 //! ```rust
 //! #[macro_use]
 //! extern crate mopa;
+//! #[macro_use]
+//! extern crate parse_generics_shim;
 //!
 //! struct Bear {
 //!     // This might be a pretty fat bear.
@@ -320,6 +324,7 @@ macro_rules! mopafy_only_core {
 ///
 ///    ```rust
 ///    # #[macro_use] extern crate mopa;
+///    # #[macro_use] extern crate parse_generics_shim;
 ///    trait Trait: mopa::Any { }
 ///    mopafy!(Trait);
 ///    trait Params<A, B>: mopa::Any { }
@@ -331,10 +336,11 @@ macro_rules! mopafy_only_core {
 ///
 ///    ```rust
 ///    # #[macro_use] extern crate mopa;
+///    # #[macro_use] extern crate parse_generics_shim;
 ///    # trait Trait: mopa::Any { }
-///    mopafy!(Trait, only core);
+///    mopafy_only_core!(Trait);
 ///    trait Params<A, B>: mopa::Any { }
-///    mopafy!(Params<A, B>, only core);
+///    mopafy_only_core!(Params<A, B>);
 ///    # fn main() { }
 ///    ```
 ///
@@ -349,6 +355,7 @@ macro_rules! mopafy_only_core {
 ///    # // channels where #[feature] isn’t allowed.
 ///    # #![feature(alloc)]
 ///    # #[macro_use] extern crate mopa;
+///    # #[macro_use] extern crate parse_generics_shim;
 ///    # extern crate alloc;
 ///    # trait Trait: mopa::Any { }
 ///    use alloc::boxed::Box;
@@ -362,7 +369,7 @@ macro_rules! mopafy {
     // Implement the full suite of `Any` methods: those of `&Any`, `&mut Any` and `Box<Any>`.
     //
     // If you’re not using libstd, you’ll need to `use alloc::boxed::Box;`, or forego the
-    // `Box<Any>` methods by just using `mopafy!(Trait, only core);`.
+    // `Box<Any>` methods by just using `mopafy_only_core!(Trait);`.
     ($trait_:ident $($t:tt)*) => {
         mopafy_only_core!($trait_ $($t)*);
         parse_generics_shim! {
@@ -375,9 +382,9 @@ macro_rules! mopafy {
 
 #[cfg(test)]
 mod tests {
-    use std::prelude::v1::*;
     #[macro_use]
     use parse_generics_shim;
+    use std::prelude::v1::*;
 
     trait Float {}
     impl Float for f32 {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,25 @@ macro_rules! as_item {
 }
 
 #[macro_export]
+macro_rules! shr_to_gt_gt{
+    (@inner () ( $($out:tt)* ) ( $m:ident $($args:tt)* ) ) => {
+        $m ! ( ( $($args)* ) ( $($out)* ) );
+    };
+    
+    (@inner ( >> $($input:tt)* ) ( $($out:tt)* ) ( $m:ident $($args:tt)* ) ) => {
+        shr_to_gt_gt!(@inner ( $($input)* ) ( $($out)* > > ) ( $m $($args)* ) );
+    };
+    
+    (@inner ( $a:tt $($input:tt)* ) ( $($out:tt)* ) ( $m:ident $($args:tt)* ) ) => {
+        shr_to_gt_gt!(@inner ( $($input)* ) ( $($out)* $a ) ( $m $($args)* ) );
+    };
+    
+    ( ( $($input:tt)* ) then $m:ident ! ($($args:tt)*) ) => {
+        shr_to_gt_gt!(@inner ( $($input)* ) () ( $m $($args)* ) );
+    };
+}
+
+#[macro_export]
 macro_rules! mopafy_internal {
     // Not using libstd or liballoc? You can get the &Any and &mut Any methods by specifying what
     // libcore is here, e.g. `mopafy!(Trait, core = core)`, but you won’t get the `Box<Any>`
@@ -293,13 +312,20 @@ macro_rules! mopafy_only_core_internal {
 }
 
 #[macro_export]
-macro_rules! mopafy_only_core {
-    ($trait_:ident $($t:tt)*) => {
+macro_rules! mopafy_only_core_inner{
+    (( $trait_:ident ) ( $($t:tt)*) ) => {
         parse_generics_shim! {
             { .. },
             then mopafy_only_core_internal!($trait_),
             $($t)*
         }
+    };
+}
+
+#[macro_export]
+macro_rules! mopafy_only_core {
+    ($trait_:ident $($t:tt)*) => {
+        shr_to_gt_gt!(($($t)*) then mopafy_only_core_inner!($trait_));
     };
 }
 
@@ -371,6 +397,13 @@ macro_rules! mopafy {
     // `Box<Any>` methods by just using `mopafy_only_core!(Trait);`.
     ($trait_:ident $($t:tt)*) => {
         mopafy_only_core!($trait_ $($t)*);
+        shr_to_gt_gt!(($($t)*) then mopafy_inner!($trait_));
+    };
+}
+
+#[macro_export]
+macro_rules! mopafy_inner{
+    (( $trait_:ident ) ( $($t:tt)*) ) => {
         parse_generics_shim! {
             { .. },
             then mopafy_internal!($trait_),
@@ -439,11 +472,7 @@ mod tests {
         fn roundness(&self) -> i16;
     }
 
-    mopafy!(Constrained<X, F: Float, D: Deep<F> >);
-    //                                         ^
-    // This space is currently very important, if you don't include it, the compiler
-    // will think it's a bitshift operator `>>` instead of syntax for generics.
-    // Maybe there is a way to fix this?
+    mopafy!(Constrained<X, F: Float, D: Deep<F>>);
 
     impl<F: Float, D: Deep<F>> Constrained<u8, F, D> for Benny {
         fn roundness(&self) -> i16 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,25 +189,6 @@ macro_rules! as_item {
 }
 
 #[macro_export]
-macro_rules! shr_to_gt_gt{
-    (@inner () ( $($out:tt)* ) ( $m:ident $($args:tt)* ) ) => {
-        $m ! ( ( $($args)* ) ( $($out)* ) );
-    };
-    
-    (@inner ( >> $($input:tt)* ) ( $($out:tt)* ) ( $m:ident $($args:tt)* ) ) => {
-        shr_to_gt_gt!(@inner ( $($input)* ) ( $($out)* > > ) ( $m $($args)* ) );
-    };
-    
-    (@inner ( $a:tt $($input:tt)* ) ( $($out:tt)* ) ( $m:ident $($args:tt)* ) ) => {
-        shr_to_gt_gt!(@inner ( $($input)* ) ( $($out)* $a ) ( $m $($args)* ) );
-    };
-    
-    ( ( $($input:tt)* ) then $m:ident ! ($($args:tt)*) ) => {
-        shr_to_gt_gt!(@inner ( $($input)* ) () ( $m $($args)* ) );
-    };
-}
-
-#[macro_export]
 macro_rules! mopafy_internal {
     // Not using libstd or liballoc? You can get the &Any and &mut Any methods by specifying what
     // libcore is here, e.g. `mopafy!(Trait, core = core)`, but you won’t get the `Box<Any>`
@@ -312,20 +293,13 @@ macro_rules! mopafy_only_core_internal {
 }
 
 #[macro_export]
-macro_rules! mopafy_only_core_inner{
-    (( $trait_:ident ) ( $($t:tt)*) ) => {
+macro_rules! mopafy_only_core {
+    ($trait_:ident $($t:tt)*) => {
         parse_generics_shim! {
             { .. },
             then mopafy_only_core_internal!($trait_),
             $($t)*
         }
-    };
-}
-
-#[macro_export]
-macro_rules! mopafy_only_core {
-    ($trait_:ident $($t:tt)*) => {
-        shr_to_gt_gt!(($($t)*) then mopafy_only_core_inner!($trait_));
     };
 }
 
@@ -397,13 +371,6 @@ macro_rules! mopafy {
     // `Box<Any>` methods by just using `mopafy_only_core!(Trait);`.
     ($trait_:ident $($t:tt)*) => {
         mopafy_only_core!($trait_ $($t)*);
-        shr_to_gt_gt!(($($t)*) then mopafy_inner!($trait_));
-    };
-}
-
-#[macro_export]
-macro_rules! mopafy_inner{
-    (( $trait_:ident ) ( $($t:tt)*) ) => {
         parse_generics_shim! {
             { .. },
             then mopafy_internal!($trait_),


### PR DESCRIPTION
This is an improvement of PR #4.
You can now do the following:

``` rust
mopafy!(Constrained<X, F: Float, D: Deep<F>>);
```

I had to rename `mopafy!(..., only core)` to `mopafy_only_core!(...)` and add a dependency to [rust-parse-generics](https://github.com/DanielKeep/rust-parse-generics/).
